### PR TITLE
Changes to work with new version of chp-opt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,13 @@ BINARY=chp2prs.$(EXT)
 TARGETS=$(BINARY)
 
 OBJS=main.o check_chp.o cartographer.o
-OBJS+=../chp-optimize/chp-opt.o ../chp-optimize/var-table.o ../chp-optimize/lattice.o ../chp-optimize/expr-helpers.o ../chp-optimize/canonical.o ../chp-optimize/sequencers.o ../chp-optimize/deadcode.o
 
 SRCS=$(OBJS:.o=.cc)
 
 include $(VLSI_TOOLS_SRC)/scripts/Makefile.std
 
 $(BINARY): $(LIB) $(OBJS) $(ACTDEPEND)
-	$(CXX) $(CFLAGS) $(OBJS) -o $(BINARY) $(LIBACTPASS) 
+	$(CXX) $(CFLAGS) $(OBJS) -o $(BINARY) $(LIBACTPASS) -lchpopt
 
 update: update_channel update_globals update_syn update_bundled
 
@@ -42,7 +41,7 @@ update_channel:
 	else \
 		(echo "Error: no channel file to update") \
 	fi
-	
+
 update_globals:
 	@if [ -d lib/ -a -f lib/globals.act ] ; \
 	then \
@@ -69,7 +68,7 @@ update_syn:
 	else \
 		(echo "Error: no syn file to update") \
 	fi
-	
+
  # BUNDLED File Copy for namespace
 update_bundled:
 	@if [ -d lib/ -a -f lib/bundled.act ] ; \

--- a/main.cc
+++ b/main.cc
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <act/act.h>
 #include <act/passes/netlist.h>
-#include "../chp-optimize/chp-opt.h"
+#include <act/chp-opt/optimize.h>
 #include "config.h"
 #include "check_chp.h"
 #include "cartographer.h"
@@ -72,14 +72,14 @@ int main(int argc, char **argv)
   {
     fatal_error("Process `%s' is not expanded.", argv[2]);
   }
-  
-  ChpOpt::optimize(p);
 
   /* extract the chp */
   if (p->lang == NULL || p->lang->getchp() == NULL)
   {
     fatal_error("Input file `%s' does not have any chp.", argv[2]);
   }
+
+  ChpOpt::optimize(p, a->getTypeFactory());
 
   check_chp(p);
   generate_act(p, argv[3], false, 0);


### PR DESCRIPTION
- Link with chp-opt as library based on $ACT_HOME, instead of using hardcoded paths
- Pass TypeFactory argument to optimization, to match API change

To make this work, pull the latest version of chp-opt from https://git.yale.edu/avlsi/chp-optimize, make it, then switch to this project, make clean, and make. 