### PR TITLE
Qdi standard cell update

### DIFF
--- a/lib/qdi/stdcells.act
+++ b/lib/qdi/stdcells.act
@@ -107,8 +107,8 @@ namespace syn {
     prs {
       A.d.d[0].f & B.d.d[0].f -> _t-
       A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _t+
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -130,17 +130,9 @@ namespace syn {
     bool _f, _t;
     prs {
       A.d.d[0].f & B.d.d[0].f & C.d.d[0].f -> _t-
-      A.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) |
-      B.d.d[0].t &
-      A.d.d[0].f &
-      (C.d.d[0].t | C.d.d[0].f) |
-      C.d.d[0].t &
-      B.d.d[0].f &
-      A.d.d[0].f -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _f+
+      A.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) | B.d.d[0].t & A.d.d[0].f & (C.d.d[0].t | C.d.d[0].f) | C.d.d[0].t & B.d.d[0].f & A.d.d[0].f -> _f-
+      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _t+
+      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -162,8 +154,8 @@ namespace syn {
     prs {
       A.d.d[0].f & B.d.d[0].f -> _f-
       A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _t+
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -185,8 +177,8 @@ namespace syn {
     prs {
       A.d.d[0].f & B.d.d[0].f -> _f-
       A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _t+
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -206,10 +198,10 @@ namespace syn {
     B.r = Y.r;
     bool _f, _t;
     prs {
-      A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | A.d.d[0].t & B.d.d[0].f -> _t-
+      A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t  -> _t-
       A.d.d[0].t & B.d.d[0].t -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _t+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t &  ~B.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -230,18 +222,10 @@ namespace syn {
     C.r = Y.r;
     bool _f, _t;
     prs {
-      A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) |
-      B.d.d[0].f &
-      A.d.d[0].t &
-      (C.d.d[0].t | C.d.d[0].f) |
-      C.d.d[0].f &
-      A.d.d[0].t &
-      B.d.d[0].t -> _t-
+      A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) | B.d.d[0].f & A.d.d[0].t & (C.d.d[0].t | C.d.d[0].f) | C.d.d[0].f & A.d.d[0].t & B.d.d[0].t -> _t-
       A.d.d[0].t & B.d.d[0].t & C.d.d[0].t -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _t+
+      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -263,8 +247,8 @@ namespace syn {
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t -> _f-
       A.d.d[0].t & B.d.d[0].t -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _t+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -286,8 +270,8 @@ namespace syn {
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t -> _f-
       A.d.d[0].t & B.d.d[0].t -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _t+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -309,8 +293,8 @@ namespace syn {
     prs {
       A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f -> _t-
       A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].f -> _t+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -332,8 +316,8 @@ namespace syn {
     prs {
       A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f -> _f-
       A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _t+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -354,16 +338,11 @@ namespace syn {
     S.r = Y.r;
     bool _f, _t;
     prs {
-      A.d.d[0].t & S.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t &
-      S.d.d[0].f &
-      (A.d.d[0].f | A.d.d[0].t) -> _f-
-      A.d.d[0].f & S.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].f &
-      S.d.d[0].f &
-      (A.d.d[0].f | A.d.d[0].t) -> _t-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~S.d.d[0].t &
-      ~S.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~S.d.d[0].t &
-      ~S.d.d[0].f -> _f+
+      A.d.d[0].t & S.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & S.d.d[0].f & (A.d.d[0].f | A.d.d[0].t) -> _f-
+      ~A.d.d[0].t & ~S.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~S.d.d[0].f & ~A.d.d[0].f -> _f+
+      A.d.d[0].f & S.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & S.d.d[0].f & (A.d.d[0].f | A.d.d[0].t) -> _t-
+      ~A.d.d[0].f & ~S.d.d[0].t & ~B.d.d[0].t & ~B.d.d[0].f & ~S.d.d[0].f & ~A.d.d[0].t-> _t+
+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -384,15 +363,10 @@ namespace syn {
     C.r = Y.r;
     bool _f, _t;
     prs {
-      A.d.d[0].f & B.d.d[0].f & C.d.d[0].t | C.d.d[0].f &
-      (A.d.d[0].t | A.d.d[0].f) &
-      (B.d.d[0].t | B.d.d[0].f) -> _t-
-      (A.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].t & A.d.d[0].f) &
-      C.d.d[0].t -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _f+
+      A.d.d[0].f & B.d.d[0].f & C.d.d[0].t | C.d.d[0].f & (A.d.d[0].t | A.d.d[0].f) & (B.d.d[0].t | B.d.d[0].f) -> _t-
+      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t-> _t+
+      (A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f) & C.d.d[0].t -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -413,15 +387,10 @@ namespace syn {
     C.r = Y.r;
     bool _f, _t;
     prs {
-      (A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t) &
-      C.d.d[0].f -> _t-
-      (A.d.d[0].t & B.d.d[0].t & C.d.d[0].f) | C.d.d[0].t &
-      (A.d.d[0].t | A.d.d[0].f) &
-      (B.d.d[0].t | B.d.d[0].f) -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f -> _f+
+      (A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t) & C.d.d[0].f -> _t-
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t & ~C.d.d[0].f & ~C.d.d[0].t -> _t+
+      (A.d.d[0].t & B.d.d[0].t & C.d.d[0].f) | C.d.d[0].t & ( A.d.d[0].f | A.d.d[0].t) & (B.d.d[0].f |B.d.d[0].t ) -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].f & ~C.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -443,20 +412,10 @@ namespace syn {
     D.r = Y.r;
     bool _f, _t;
     prs {
-      (A.d.d[0].f & B.d.d[0].f & (C.d.d[0].f | C.d.d[0].t) &
-      (D.d.d[0].f | D.d.d[0].t)) |
-      (C.d.d[0].f & D.d.d[0].f & (A.d.d[0].f | A.d.d[0].t) &
-      (B.d.d[0].f | B.d.d[0].t)) -> _t-
-      (A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f) &
-      (C.d.d[0].t & (D.d.d[0].f | D.d.d[0].t) | D.d.d[0].t & C.d.d[0].f) -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f &
-      ~D.d.d[0].t &
-      ~D.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f &
-      ~D.d.d[0].t &
-      ~D.d.d[0].f -> _f+
+      (A.d.d[0].f & B.d.d[0].f & (C.d.d[0].f | C.d.d[0].t) & (D.d.d[0].f | D.d.d[0].t)) | (C.d.d[0].f & D.d.d[0].f & (A.d.d[0].t | A.d.d[0].f) & (B.d.d[0].t | B.d.d[0].f)) -> _t-
+      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f & ~C.d.d[0].t & ~D.d.d[0].f & ~D.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].t-> _t+
+      (A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f) & (C.d.d[0].t & (D.d.d[0].f | D.d.d[0].t) | D.d.d[0].t & C.d.d[0].f) -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f & ~C.d.d[0].t & ~D.d.d[0].f & ~D.d.d[0].t & ~C.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -478,20 +437,10 @@ namespace syn {
     D.r = Y.r;
     bool _f, _t;
     prs {
-      (A.d.d[0].f & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].f & A.d.d[0].t) &
-      (C.d.d[0].f & (D.d.d[0].f | D.d.d[0].t) | D.d.d[0].f & C.d.d[0].t) -> _t-
-      (A.d.d[0].t & B.d.d[0].t & (C.d.d[0].f | C.d.d[0].t) &
-      (D.d.d[0].f | D.d.d[0].t)) |
-      (C.d.d[0].t & D.d.d[0].t & (A.d.d[0].f | A.d.d[0].t) &
-      (B.d.d[0].f | B.d.d[0].t)) -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f &
-      ~D.d.d[0].t &
-      ~D.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t &
-      ~C.d.d[0].f &
-      ~D.d.d[0].t &
-      ~D.d.d[0].f -> _f+
+      (A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t) & (C.d.d[0].f & (D.d.d[0].t | D.d.d[0].f) | D.d.d[0].f & C.d.d[0].t) -> _t-
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t  & ~C.d.d[0].f & ~D.d.d[0].t & ~D.d.d[0].f & ~C.d.d[0].t -> _t+
+      (A.d.d[0].t & B.d.d[0].t & (C.d.d[0].f | C.d.d[0].t) & (D.d.d[0].f | D.d.d[0].t)) | (C.d.d[0].t & D.d.d[0].t & (A.d.d[0].f | A.d.d[0].t) & (B.d.d[0].f | B.d.d[0].t)) -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].f & ~C.d.d[0].t & ~D.d.d[0].f & ~D.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -516,15 +465,15 @@ namespace syn {
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t -> _fc-
       A.d.d[0].t & B.d.d[0].t -> _tc-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _tc+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _fc+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _tc+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _fc+
       _fc => YC.d.d[0].f-
       _tc => YC.d.d[0].t-
 
       A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f -> _ts-
       A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t -> _fs-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _ts+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f -> _fs+
+      ~A.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].f -> _ts+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _fs+
       _fs => YS.d.d[0].f-
       _ts => YS.d.d[0].t-
     }
@@ -551,24 +500,16 @@ namespace syn {
     bool _st, _sf, _ct, _cf;
     prs {
       A.d.d[0].t & B.d.d[0].t | (A.d.d[0].t | B.d.d[0].t) & C.d.d[0].t -> _ct-
-      ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &
-      ~B.d.d[0].f -> _ct+
+      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].t & ~C.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].f-> _ct+
 
       A.d.d[0].f & B.d.d[0].f | (A.d.d[0].f | B.d.d[0].f) & C.d.d[0].f -> _cf-
-      ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &
-      ~B.d.d[0].f -> _cf+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f  & ~C.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].t & -> _cf+
 
-      C.d.d[0].t & (A.d.d[0].t & B.d.d[0].t | A.d.d[0].f & B.d.d[0].f) |
-      C.d.d[0].f &
-      (A.d.d[0].t & B.d.d[0].f | A.d.d[0].f & B.d.d[0].t) -> _st-
-      ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &
-      ~B.d.d[0].f -> _st+
+      C.d.d[0].t & (A.d.d[0].t & B.d.d[0].t | A.d.d[0].f & B.d.d[0].f) | C.d.d[0].f & (A.d.d[0].t & B.d.d[0].f | A.d.d[0].f & B.d.d[0].t) -> _st-
+      ~C.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f & -> _st+
 
-      C.d.d[0].t & (A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f) |
-      C.d.d[0].f &
-      (A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t) -> _sf-
-      ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &
-      ~B.d.d[0].f -> _sf+
+      C.d.d[0].t & (A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f) | C.d.d[0].f & (A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t) -> _sf-
+      ~C.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &  ~A.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].f -> _sf+
 
       _ct => YC.d.d[0].t-
       _cf => YC.d.d[0].f-

--- a/lib/qdi/stdcells.act
+++ b/lib/qdi/stdcells.act
@@ -59,10 +59,10 @@ namespace syn {
     _t.out[0] = Y.d.d[0].t;
   }
 
-  export defcell INVX1 <: inv<1> () {}
-  export defcell INVX2 <: inv<2> () {}
-  export defcell INVX4 <: inv<4> () {}
-  export defcell INVX8 <: inv<8> () {}
+  export defproc INVX1 <: inv<1> () {}
+  export defproc INVX2 <: inv<2> () {}
+  export defproc INVX4 <: inv<4> () {}
+  export defproc INVX8 <: inv<8> () {}
 
   /*-- clock delay buffers --*/
 
@@ -94,13 +94,13 @@ namespace syn {
     _t.out[0] = Y.d.d[0].t;
   }
 
-  export defcell BUFX1 <: buf<1> () {}
-  export defcell BUFX2 <: buf<2> () {}
-  export defcell BUFX4 <: buf<4> () {}
+  export defproc BUFX1 <: buf<1> () {}
+  export defproc BUFX2 <: buf<2> () {}
+  export defproc BUFX4 <: buf<4> () {}
 
   /*-- simple gates --*/
   export
-  defcell NOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc NOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
@@ -123,16 +123,16 @@ namespace syn {
   }
 
   export
-  defcell NOR3X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
+  defproc NOR3X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & B.d.d[0].f & C.d.d[0].f -> _t-
-      A.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) | B.d.d[0].t & A.d.d[0].f & (C.d.d[0].t | C.d.d[0].f) | C.d.d[0].t & B.d.d[0].f & A.d.d[0].f -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f -> _t+
+      A.d.d[0].t & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) | B.d.d[0].t & A.d.d[0].f & (C.d.d[0].f | C.d.d[0].t) | C.d.d[0].t & B.d.d[0].f & A.d.d[0].f -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f & ~A.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -147,15 +147,15 @@ namespace syn {
   }
 
   export
-  defcell OR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc OR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & B.d.d[0].f -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
       A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f -> _t-
-      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _t+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -170,15 +170,15 @@ namespace syn {
   }
 
   export
-  defcell OR2X2(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc OR2X2(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & B.d.d[0].f -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
       A.d.d[0].t & (B.d.d[0].f | B.d.d[0].t) | B.d.d[0].t & A.d.d[0].f -> _t-
-      ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _f+
+      ~A.d.d[0].t & ~B.d.d[0].f & ~B.d.d[0].t & ~A.d.d[0].f -> _t+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -193,14 +193,14 @@ namespace syn {
   }
 
   export
-  defcell NAND2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc NAND2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t  -> _t-
-      A.d.d[0].t & B.d.d[0].t -> _f-
       ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _t+
+      A.d.d[0].t & B.d.d[0].t -> _f-
       ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t &  ~B.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
@@ -216,16 +216,16 @@ namespace syn {
   }
 
   export
-  defcell NAND3X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
+  defproc NAND3X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
     bool _f, _t;
     prs {
-      A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) & (C.d.d[0].t | C.d.d[0].f) | B.d.d[0].f & A.d.d[0].t & (C.d.d[0].t | C.d.d[0].f) | C.d.d[0].f & A.d.d[0].t & B.d.d[0].t -> _t-
+      A.d.d[0].f & (B.d.d[0].f | B.d.d[0].t) & (C.d.d[0].f | C.d.d[0].t) | B.d.d[0].f & A.d.d[0].t & (C.d.d[0].t | C.d.d[0].f) | C.d.d[0].f & B.d.d[0].t & A.d.d[0].t  -> _t-
+      ~A.d.d[0].f & ~B.d.d[0].f & ~B.d.d[0].t & ~C.d.d[0].f & ~C.d.d[0].t & ~A.d.d[0].t -> _t+
       A.d.d[0].t & B.d.d[0].t & C.d.d[0].t -> _f-
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _t+
-      ~A.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].t & ~C.d.d[0].f -> _f+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -240,15 +240,15 @@ namespace syn {
   }
 
   export
-  defcell AND2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc AND2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t -> _f-
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       A.d.d[0].t & B.d.d[0].t -> _t-
       ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _t+
-      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -263,15 +263,15 @@ namespace syn {
   }
 
   export
-  defcell AND2X2(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc AND2X2(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
     prs {
       A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t -> _f-
+      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       A.d.d[0].t & B.d.d[0].t -> _t-
       ~A.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].t & ~B.d.d[0].t -> _t+
-      ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -286,7 +286,7 @@ namespace syn {
   }
 
   export
-  defcell XOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc XOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
@@ -309,7 +309,7 @@ namespace syn {
   }
 
   export
-  defcell XNOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
+  defproc XNOR2X1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     bool _f, _t;
@@ -332,7 +332,7 @@ namespace syn {
   }
 
   export
-  defcell MUX2X1(syn::sdtexprchan?<1> A, B, S; syn::sdtexprchan!<1> Y) {
+  defproc MUX2X1(syn::sdtexprchan?<1> A, B, S; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     S.r = Y.r;
@@ -357,7 +357,7 @@ namespace syn {
   }
 
   export
-  defcell OAI21X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
+  defproc OAI21X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
@@ -381,7 +381,7 @@ namespace syn {
   }
 
   export
-  defcell AOI21X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
+  defproc AOI21X1(syn::sdtexprchan?<1> A, B, C; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
@@ -405,7 +405,7 @@ namespace syn {
   }
 
   export
-  defcell OAI22X1(syn::sdtexprchan?<1> A, B, C, D; syn::sdtexprchan!<1> Y) {
+  defproc OAI22X1(syn::sdtexprchan?<1> A, B, C, D; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
@@ -430,7 +430,7 @@ namespace syn {
   }
 
   export
-  defcell AOI22X1(syn::sdtexprchan?<1> A, B, C, D; syn::sdtexprchan!<1> Y) {
+  defproc AOI22X1(syn::sdtexprchan?<1> A, B, C, D; syn::sdtexprchan!<1> Y) {
     A.r = Y.r;
     B.r = Y.r;
     C.r = Y.r;
@@ -439,8 +439,8 @@ namespace syn {
     prs {
       (A.d.d[0].f & (B.d.d[0].t | B.d.d[0].f) | B.d.d[0].f & A.d.d[0].t) & (C.d.d[0].f & (D.d.d[0].t | D.d.d[0].f) | D.d.d[0].f & C.d.d[0].t) -> _t-
       ~A.d.d[0].f & ~B.d.d[0].t & ~B.d.d[0].f & ~A.d.d[0].t  & ~C.d.d[0].f & ~D.d.d[0].t & ~D.d.d[0].f & ~C.d.d[0].t -> _t+
-      (A.d.d[0].t & B.d.d[0].t & (C.d.d[0].f | C.d.d[0].t) & (D.d.d[0].f | D.d.d[0].t)) | (C.d.d[0].t & D.d.d[0].t & (A.d.d[0].f | A.d.d[0].t) & (B.d.d[0].f | B.d.d[0].t)) -> _f-
-      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].f & ~C.d.d[0].t & ~D.d.d[0].f & ~D.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
+      (A.d.d[0].t & B.d.d[0].t & (C.d.d[0].t | C.d.d[0].f) & (D.d.d[0].t | D.d.d[0].f)) | (C.d.d[0].t & D.d.d[0].t & (A.d.d[0].f | A.d.d[0].t) & (B.d.d[0].f | B.d.d[0].t)) -> _f-
+      ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].t & ~C.d.d[0].f & ~D.d.d[0].t & ~D.d.d[0].f & ~A.d.d[0].f & ~B.d.d[0].f -> _f+
       _f => Y.d.d[0].f-
       _t => Y.d.d[0].t-
     }
@@ -457,7 +457,7 @@ namespace syn {
   /*--- arithmetic ---*/
 
   export
-  defcell HAX1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> YC, YS) {
+  defproc HAX1(syn::sdtexprchan?<1> A, B; syn::sdtexprchan!<1> YC, YS) {
     A.r = YS.r;
     B.r = YS.r;
     YC.r = YS.r;
@@ -503,10 +503,10 @@ namespace syn {
       ~A.d.d[0].t & ~B.d.d[0].t & ~C.d.d[0].t & ~C.d.d[0].f & ~B.d.d[0].f & ~A.d.d[0].f-> _ct+
 
       A.d.d[0].f & B.d.d[0].f | (A.d.d[0].f | B.d.d[0].f) & C.d.d[0].f -> _cf-
-      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f  & ~C.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].t & -> _cf+
+      ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f  & ~C.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].t -> _cf+
 
       C.d.d[0].t & (A.d.d[0].t & B.d.d[0].t | A.d.d[0].f & B.d.d[0].f) | C.d.d[0].f & (A.d.d[0].t & B.d.d[0].f | A.d.d[0].f & B.d.d[0].t) -> _st-
-      ~C.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f & -> _st+
+      ~C.d.d[0].t & ~A.d.d[0].t & ~B.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].f & ~C.d.d[0].f -> _st+
 
       C.d.d[0].t & (A.d.d[0].f & B.d.d[0].t | A.d.d[0].t & B.d.d[0].f) | C.d.d[0].f & (A.d.d[0].f & B.d.d[0].f | A.d.d[0].t & B.d.d[0].t) -> _sf-
       ~C.d.d[0].t & ~A.d.d[0].f & ~B.d.d[0].t &  ~A.d.d[0].t & ~B.d.d[0].f & ~C.d.d[0].f -> _sf+

--- a/test/run_basic.sh
+++ b/test/run_basic.sh
@@ -3,7 +3,12 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../../chp2prs.$EXT
+if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/chp2prs
+  echo "testing installation"
+else
+  ACTTOOL=../../chp2prs.$EXT
+fi
 
 fail=0
 faildirs=""

--- a/test/run_expr.sh
+++ b/test/run_expr.sh
@@ -3,7 +3,12 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../../chp2prs.$EXT
+if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/chp2prs
+  echo "testing installation"
+else
+  ACTTOOL=../../chp2prs.$EXT
+fi
 
 fail=0
 faildirs=""

--- a/test/run_expr_bdopt.sh
+++ b/test/run_expr_bdopt.sh
@@ -3,7 +3,12 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../../chp2prs.$EXT
+if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/chp2prs
+  echo "testing installation"
+else
+  ACTTOOL=../../chp2prs.$EXT
+fi
 
 if ! $ACT_HOME/scripts/findpkg -i expropt > /dev/null
 then

--- a/test/run_expr_qdiopt.sh
+++ b/test/run_expr_qdiopt.sh
@@ -3,7 +3,12 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../../chp2prs.$EXT
+if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/chp2prs
+  echo "testing installation"
+else
+  ACTTOOL=../../chp2prs.$EXT
+fi
 
 if ! $ACT_HOME/scripts/findpkg -i expropt > /dev/null
 then


### PR DESCRIPTION
This pull requests reduces the number of required extra cells for the qdi datapath to 13 from 21, by reshuffeling the PRS rules to logical equivalent versions.

@rmanohar I also patched the tests to run on the install if environment variable $ACT_TEST_INSTALL is exported, I should have put it in a separate pull request, let me know if you prefer that and if you think i should do it differently.

