### PR TITLE
Make tests fail and ci extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2
 
 jobs:
-   ubuntu20:
-     # Ubuntu 20
+   ubuntu22:
+     # Ubuntu 22
      docker:
-       - image: ubuntu:20.04
+       - image: ubuntu:22.04
      steps:
        - checkout
        - run:
@@ -16,7 +16,7 @@ jobs:
           # tzdata is interactive so force no interaction
           command: |
               apt-get -q update -y
-              DEBIAN_FRONTEND=noninteractive apt-get -q install -y libedit-dev zlib1g-dev m4 build-essential git yosys 
+              DEBIAN_FRONTEND=noninteractive apt-get -q install -y libedit-dev zlib1g-dev m4 build-essential git yosys terminfo
        - run: 
           name: Install act base
           command: |
@@ -32,18 +32,14 @@ jobs:
               make install
               cd ..
        - run: 
-          name: Install interACT base
+          name: Install act stdlib
           command: |
-              git clone https://github.com/asyncvlsi/interact
+              git clone https://github.com/asyncvlsi/stdlib --depth 1
               export ACT_HOME=`pwd`/install
               export PATH=$ACT_HOME/bin:$PATH
               export VLSI_TOOLS_SRC=`pwd`/act
-              cd interact
-              echo "===== build interACT base ====="
-              ./configure
-              make depend
-              make
-              echo "===== install interACT base ====="
+              cd stdlib
+              echo "===== install act stdlib ====="
               make install
               cd ..
        - run: 
@@ -58,52 +54,16 @@ jobs:
               make
               echo "===== install act addon ====="
               make install
+              
               echo "===== test act addon ====="
+              export ACT_TEST_VERBOSE=1
+              make runtest
+              export ACT_TEST_install=1
               make runtest
 
-   centos8:
-    # centos 8 / rhel 8
-     docker:
-       - image: centos:8
-     steps:
-       - checkout
-       - run:           
-          name: Dependencies
-          command: |
-              yum install -y 'dnf-command(config-manager)'
-              yum config-manager --set-enabled powertools -y
-              yum install -y gcc gcc-c++ diffutils make libedit-devel zlib-devel m4 git
-       - run: 
-          name: Install act base
-          command: |
-              git clone https://github.com/asyncvlsi/act
-              mkdir install
-              export ACT_HOME=`pwd`/install
-              cd act
-              echo "===== build act base ====="
-              export VLSI_TOOLS_SRC=`pwd`
-              ./configure $ACT_HOME
-              ./build
-              echo "===== install act base ====="
-              make install
-              cd ..
-       - run: 
-          name: Build install and test
-          command: |
-              export ACT_HOME=`pwd`/install
-              export PATH=$ACT_HOME/bin:$PATH
-              export VLSI_TOOLS_SRC=`pwd`/act
-              echo "===== build act addon ====="
-              make depend
-              make
-              echo "===== install act addon ====="
-              make install
-              echo "===== test act addon  ====="
-              make runtest
 workflows:
    version: 2
    build:
      jobs: 
-        - ubuntu20
-        #- centos8 #yosys not avalible set up compile
+        - ubuntu22
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,20 @@ jobs:
               make install
               cd ..
        - run: 
+          name: Install act expropt
+          command: |
+              git clone https://github.com/asyncvlsi/expropt --depth 1
+              export ACT_HOME=`pwd`/install
+              export PATH=$ACT_HOME/bin:$PATH
+              export VLSI_TOOLS_SRC=`pwd`/act
+              cd expropt
+              echo "===== build act expropt addon ====="
+              ./configure
+              make
+              echo "===== install act expropt addon ====="
+              make install
+              cd ..
+       - run: 
           name: Build install and test
           command: |
               export ACT_HOME=`pwd`/install

--- a/test/run.sh
+++ b/test/run.sh
@@ -12,7 +12,7 @@ echo
 echo
 echo "${und}BASELINE MODE${normal}"
 echo
-./run_expr.sh
+./run_expr.sh || exit 1
 
 echo
 echo "${und}QDI external EXPRESSION syntesis MODE${normal}"
@@ -20,13 +20,13 @@ echo "${und}QDI external EXPRESSION syntesis MODE${normal}"
 if ! command -v yosys >/dev/null; then
   echo "yosys not found skipping yosys tests"
 else
-./run_expr_qdiopt.sh yosys
+./run_expr_qdiopt.sh yosys || exit 1
 fi
 
 if ! command -v genus >/dev/null; then
   echo "genus not found skipping genus tests"
 else
-./run_expr_qdiopt.sh genus
+./run_expr_qdiopt.sh genus || exit 1
 fi
 
 echo
@@ -36,12 +36,12 @@ echo
 if ! command -v yosys >/dev/null; then
   echo "yosys not found skipping yosys tests"
 else
-./run_expr_bdopt.sh yosys
+./run_expr_bdopt.sh yosys || exit 1
 fi
 
 if ! command -v genus >/dev/null; then
   echo "genus not found skipping genus tests"
 else
-./run_expr_bdopt.sh genus
+./run_expr_bdopt.sh genus || exit 1
 fi
 

--- a/test/run_basic.sh
+++ b/test/run_basic.sh
@@ -3,9 +3,10 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../../chp2prs.$EXT ]; then
   ACTTOOL=$ACT_HOME/bin/chp2prs
   echo "testing installation"
+echo
 else
   ACTTOOL=../../chp2prs.$EXT
 fi
@@ -45,13 +46,20 @@ EOF
 	    echo "${bold}*** simulation failed ***${normal}"
 	    faildirs="${faildirs} ${1}-sim"
 	    failed=1
+        if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/prsim.out
+        fi
 	    echo	
 	fi
     else
 	echo "${bold}*** circuit construction failed ***${normal}"
 	faildirs="${faildirs} ${1}-ckt"
 	failed=1
-        echo
+    if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/sdt.act
+            cat $1/run/test.prs
+    fi
+    echo
     fi
 }
 

--- a/test/run_expr.sh
+++ b/test/run_expr.sh
@@ -3,9 +3,10 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../../chp2prs.$EXT ]; then
   ACTTOOL=$ACT_HOME/bin/chp2prs
   echo "testing installation"
+echo
 else
   ACTTOOL=../../chp2prs.$EXT
 fi
@@ -45,12 +46,19 @@ EOF
 	    echo "${bold}*** simulation failed ***${normal}"
 	    faildirs="${faildirs} ${1}-sim"
 	    failed=1
+        if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/prsim.out
+        fi
 	    echo	
 	fi
     else
 	echo "${bold}*** circuit construction failed ***${normal}"
 	faildirs="${faildirs} ${1}-ckt"
 	failed=1
+    if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/sdt.act
+            cat $1/run/test.prs
+    fi
         echo
     fi
 }

--- a/test/run_expr_bdopt.sh
+++ b/test/run_expr_bdopt.sh
@@ -3,9 +3,10 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../../chp2prs.$EXT ]; then
   ACTTOOL=$ACT_HOME/bin/chp2prs
   echo "testing installation"
+echo
 else
   ACTTOOL=../../chp2prs.$EXT
 fi
@@ -53,12 +54,19 @@ EOF
 	    echo "${bold}*** simulation failed ***${normal}"
 	    faildirs="${faildirs} ${1}-sim"
 	    failed=1
+        if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/prsim.out
+        fi
 	    echo	
 	fi
     else
 	echo "${bold}*** circuit construction failed ***${normal}"
 	faildirs="${faildirs} ${1}-ckt"
 	failed=1
+    if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/sdt.act
+            cat $1/run/test.prs
+    fi
         echo
     fi
     echo

--- a/test/run_expr_qdiopt.sh
+++ b/test/run_expr_qdiopt.sh
@@ -3,9 +3,10 @@
 ARCH=`$ACT_HOME/scripts/getarch`
 OS=`$ACT_HOME/scripts/getos`
 EXT=${ARCH}_${OS}
-if [ -z $ACT_TEST_INSTALL ] || [ ! -f ../../chp2prs.$EXT ]; then
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../../chp2prs.$EXT ]; then
   ACTTOOL=$ACT_HOME/bin/chp2prs
   echo "testing installation"
+echo
 else
   ACTTOOL=../../chp2prs.$EXT
 fi
@@ -51,12 +52,19 @@ EOF
 	    echo "${bold}*** simulation failed ***${normal}"
 	    faildirs="${faildirs} ${1}-sim"
 	    failed=1
+        if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/prsim.out
+        fi
 	    echo	
 	fi
     else
 	echo "${bold}*** circuit construction failed ***${normal}"
 	faildirs="${faildirs} ${1}-ckt"
 	failed=1
+    if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            cat $1/run/sdt.act
+            cat $1/run/test.prs
+    fi
         echo
     fi
     echo 


### PR DESCRIPTION
this PR includes:
- make test now returns exit 1 on failure and not exit 0
- fixed the CI as stdlib is also required to run tests
- added exprop to ci as its now public
- fixed a mistake in the $ACT_TEST_INSTALL mode that would check for the env var wrongly
- removed centos 8 completly from the CI
- added $ACT_TEST_VERBOSE mode for detailed printing on failure

required for https://github.com/asyncvlsi/actflow/pull/1